### PR TITLE
Only stop workflow when npm audit fails with high or critical

### DIFF
--- a/.github/workflows/githubpagesdeploy.yml
+++ b/.github/workflows/githubpagesdeploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci
 
       - name: Scan for vulnerabilities
-        run: npm audit
+        run: npm audit --audit-level=high
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Current moderate vulnerabilities arise from dependencies of tfjs-vis which is only used to display the model summary, not exposing the vulnerability to user. We could allow for a more granular control and only let tfjs-vis to have moderate but for the user case that is a bit of overkill. For the time being I will just allow moderate vulnerabilities on npm audit.